### PR TITLE
add default content-type on ping to integrate with webserver

### DIFF
--- a/app/src/main/java/cis5550/generic/Master.java
+++ b/app/src/main/java/cis5550/generic/Master.java
@@ -38,6 +38,7 @@ public class Master {
         Server.get("/ping", (req, res) -> {
             String id = req.queryParams("id");
             String port = req.queryParams("port");
+            res.header("Content-Type", "text/plain");
             if (id == null || port == null) {
                 res.status(400, "Invalid request");
             }


### PR DESCRIPTION
Zed's web server expects content type to be explicitly defined whereas arnav's kvs webserver implicitly defines it and that was causing integration issues